### PR TITLE
benchmark: also run Penthouse execution in parallel

### DIFF
--- a/examples/benchmark.js
+++ b/examples/benchmark.js
@@ -97,30 +97,30 @@ staticServer.listen(8000, async () => {
     console.log("Start CriticalCss Benchmark");
     const criticalcss = require("criticalcss");
     console.time("CriticalCss");
-    const criticalCssWrapper = async () => {
-        for (const url of urls) {
-            await new Promise(resolve => {
-                criticalcss.getRules(path.join(rootDir, "/test/data/test.css"), function (err, output) {
-                    criticalcss.findCritical(url, {
-                        rules:        JSON.parse(output),
-                        width:        1920,
-                        height:       1080,
-                        forceInclude: [
-                            ".forceInclude"
-                        ]
-                    }, function (err, output) {
-                        if (err) {
-                            throw new Error(err);
-                        } else {
-                            resolve(output);
-                        }
-                    });
-                });
-            })
-        }
-        return;
-    };
-    await criticalCssWrapper();
+    try {
+        await Promise.all(urls.map(url => {
+          return new Promise(resolve => {
+              criticalcss.getRules(path.join(rootDir, "/test/data/test.css"), function (err, output) {
+                  criticalcss.findCritical(url, {
+                      rules:        JSON.parse(output),
+                      width:        1920,
+                      height:       1080,
+                      forceInclude: [
+                          ".forceInclude"
+                      ]
+                  }, function (err, output) {
+                      if (err) {
+                          throw new Error(err);
+                      } else {
+                          resolve(output);
+                      }
+                  });
+              });
+        });
+      }));
+    } catch (err) {
+      console.error(err);
+    }
     console.timeEnd("CriticalCss");
 
     /**

--- a/examples/benchmark.js
+++ b/examples/benchmark.js
@@ -72,24 +72,22 @@ staticServer.listen(8000, async () => {
     console.log("Start Penthouse Benchmark");
     const penthouse = require('penthouse');
     console.time("Penthouse");
-    for (const url of urls) {
-        try {
+    try {
+      await Promise.all(urls.map(url => {
+        return penthouse({
+            url:             url,
+            css:             rootDir + "/test/data/test.css",
+            width:           1920,
+            height:          1080,
+            forceInclude:    [
+                ".forceInclude"
+            ],
+            blockJsRequests: false
 
-            const extracedCss = await penthouse({
-                url:             url,
-                css:             rootDir + "/test/data/test.css",
-                width:           1920,
-                height:          1080,
-                forceInclude:    [
-                    ".forceInclude"
-                ],
-                blockJsRequests: false
-
-            });
-
-        } catch (err) {
-            console.error(err);
-        }
+        });
+      }))
+    } catch (err) {
+      console.error(err);
     }
     console.timeEnd("Penthouse");
 
@@ -126,7 +124,7 @@ staticServer.listen(8000, async () => {
     console.timeEnd("CriticalCss");
 
     /**
-     * CRITICALCSS
+     * CRITICAL
      */
     console.log("Start Critical Benchmark");
     const critical = require('critical');
@@ -151,5 +149,3 @@ staticServer.listen(8000, async () => {
 }).on("error", (err) => {
     console.error(err)
 });
-
-


### PR DESCRIPTION
Hey! While the code looks clean from what I've seen so far, the benchmark has a bug. You were running Penthouse calls in sequence, and the other libraries in parallel.

<img width="393" alt="screen shot 2018-07-07 at 19 43 13" src="https://user-images.githubusercontent.com/7192832/42413330-0af30f0e-821e-11e8-9325-04ff062b8eb1.png">
With this change, on my machine Penthouse is now faster than crittr... Perhaps the benchmark is not representative of the performance gains your library has made (i.e. too simple). In either case, would appreciate if you updated your chart and communication since it's not so far accurate.

Cheers